### PR TITLE
bci_chunk_inspector: lbci module seems to be named bci in some cases

### DIFF
--- a/lua-aplicado/bci_chunk_inspector.lua
+++ b/lua-aplicado/bci_chunk_inspector.lua
@@ -31,7 +31,10 @@ end
 --------------------------------------------------------------------------------
 
 -- Doing require this late to allow the LJ2 check above.
-local bci = require 'inspector'
+
+-- NB: bci may be a bit insane
+declare 'inspector'
+local bci = pcall(require, 'bci') or require 'inspector'
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
...But it still changes `inspector` global,
so `require_and_declare` can't cope with that.